### PR TITLE
NSUserActivity.webpageURL only handles http(s) urls, ensure no other scheme used

### DIFF
--- a/Client/Helpers/SpotlightHelper.swift
+++ b/Client/Helpers/SpotlightHelper.swift
@@ -47,6 +47,10 @@ class SpotlightHelper: NSObject {
     }
 
     func update(pageContent: [String: String], forURL url: NSURL) {
+        if !url.scheme.startsWith("http") {
+            return
+        }
+
         var activity: NSUserActivity
         if let currentActivity = self.activity where currentActivity.webpageURL == url {
             activity = currentActivity


### PR DESCRIPTION
Non-http url schemes will throw, and make things go boom. In Brave about: urls are hitting this code, and crashing; the use of about: urls is slightly different in that context, but regardless this safety check should be in place.

Link to doc which explains the throw for non http(s):
https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSUserActivity_Class/#//apple_ref/occ/instp/NSUserActivity/webpageURL
